### PR TITLE
Remove dependency on opencv-python to allow users to select their OpenCV version themselves

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 opencv-wrapper = {editable = true,path = "."}
+opencv-python-headless = "*"
 
 [dev-packages]
 sphinx-autodoc-typehints = "*"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ enhancement proposals!
 ## Installation
 Getting started is easy, using pip or pipenv! 
 ```bash
-pip(env) install opencv-wrapper
+pip(env) install opencv-wrapper opencv-python
 ```
-This also installs the dependencies `opencv-python` and `numpy`, if not already present.
+
+Note that you must install `opencv-python` separately. The reason is so that
+you can select the appropriate package from `opencv-python` and
+`opencv-python-headless`, or instead opt to compile the Python bindings are
+part of the OpenCV source tree yourself.
 
 ## Examples
 ### Reading videos

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,7 +6,7 @@ Installation
 
 Getting started is easy, using pip or pipenv!::
 
-    pip(env) install opencv-wrapper
+    pip(env) install opencv-wrapper opencv-python
 
 Reading and writing
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 
-requirements = ["numpy<=1.16.2", "opencv-python<=4.0.1"]
+requirements = ["numpy"]
 
 if sys.version_info[1] == 6:
     requirements.append("dataclasses")


### PR DESCRIPTION
See https://pypi.org/project/opencv-python/

>> There are four different packages and you should select only one of them.

I think you should remove the dependency on opencv-python, so users can select opencv-python-headless if they need. I realise this isn't ideal, but since Python doesn't have any kind of metapackages or way of multiple packages "providing" the same one, this is the best option I think.